### PR TITLE
Export the schema as a JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 # Generated types
 *.d.ts
 *.d.ts.map
-!/lib/types/**/*.d.ts
 
 # Library specific ones
 !/.vscode/extensions.json
+/schema.json

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "index.d.ts.map"
+    "index.d.ts.map",
+    "schema.json"
   ],
   "scripts": {
     "build:0": "run-s clean",
     "build:1-declaration": "tsc -p declaration.tsconfig.json",
+    "build:2-schema-file": "echo \"console.log(JSON.stringify(require('.').socketYmlSchema, undefined, 2))\" | node > schema.json",
     "build": "run-s build:*",
     "check:dependency-check": "dependency-check '*.js' 'test/**/*.js' --no-dev",
     "check:installed-check": "installed-check -i eslint-plugin-jsdoc",


### PR DESCRIPTION
Enables use in tools that simply needs a JSON Schema file while still having the authorative source be in the js file where it is typed to match the expected parsed output and thus validated to be correct.