### PR TITLE
Make github options nullable

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,12 +179,12 @@ async function parseV1SocketConfig (parsedV1Content) {
     version: 2,
     projectIgnorePaths: parsedV1Content?.ignore ?? [],
     issueRules: parsedV1Content?.issues ?? {},
-    githubApp: {}
+    githubApp: {
+      ...('enabled' in parsedV1Content ? { enabled: parsedV1Content.enabled } : {}),
+      ...('pullRequestAlertsEnabled' in parsedV1Content ? { pullRequestAlertsEnabled: parsedV1Content.pullRequestAlertsEnabled } : {}),
+      ...('projectReportsEnabled' in parsedV1Content ? { projectReportsEnabled: parsedV1Content.projectReportsEnabled } : {}),
+    }
   }
-
-  if ('enabled' in parsedV1Content) v2.githubApp.enabled = parsedV1Content.enabled
-  if ('pullRequestAlertsEnabled' in parsedV1Content) v2.githubApp.pullRequestAlertsEnabled = parsedV1Content.pullRequestAlertsEnabled
-  if ('projectReportsEnabled' in parsedV1Content) v2.githubApp.projectReportsEnabled = parsedV1Content.projectReportsEnabled
 
   return v2
 }

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ const { socketYmlSchemaV1 } = require('./lib/v1')
 
 /**
  * @typedef SocketYmlGitHub
- * @property {boolean} enabled enable/disable the Socket.dev GitHub app entirely
- * @property {boolean} projectReportsEnabled enable/disable Github app project report checks
- * @property {boolean} pullRequestAlertsEnabled enable/disable GitHub app pull request alert checks
+ * @property {boolean} [enabled] enable/disable the Socket.dev GitHub app entirely
+ * @property {boolean} [projectReportsEnabled] enable/disable Github app project report checks
+ * @property {boolean} [pullRequestAlertsEnabled] enable/disable GitHub app pull request alert checks
  */
 
 /**
@@ -43,13 +43,13 @@ const socketYmlSchema = {
     githubApp: {
       type: 'object',
       properties: {
-        enabled: { type: 'boolean', default: true },
-        projectReportsEnabled: { type: 'boolean', default: true },
-        pullRequestAlertsEnabled: { type: 'boolean', default: true },
+        enabled: { type: 'boolean', nullable: true },
+        projectReportsEnabled: { type: 'boolean', nullable: true },
+        pullRequestAlertsEnabled: { type: 'boolean', nullable: true },
       },
       required: [],
       additionalProperties: false,
-      default: { enabled: true, projectReportsEnabled: true, pullRequestAlertsEnabled: true }
+      default: {}
     },
   },
   required: ['version'],
@@ -179,12 +179,13 @@ async function parseV1SocketConfig (parsedV1Content) {
     version: 2,
     projectIgnorePaths: parsedV1Content?.ignore ?? [],
     issueRules: parsedV1Content?.issues ?? {},
-    githubApp: {
-      enabled: Boolean(parsedV1Content?.enabled),
-      pullRequestAlertsEnabled: Boolean(parsedV1Content?.pullRequestAlertsEnabled),
-      projectReportsEnabled: Boolean(parsedV1Content?.projectReportsEnabled)
-    }
+    githubApp: {}
   }
+
+  if ('enabled' in parsedV1Content) v2.githubApp.enabled = parsedV1Content.enabled
+  if ('pullRequestAlertsEnabled' in parsedV1Content) v2.githubApp.pullRequestAlertsEnabled = parsedV1Content.pullRequestAlertsEnabled
+  if ('projectReportsEnabled' in parsedV1Content) v2.githubApp.projectReportsEnabled = parsedV1Content.projectReportsEnabled
+
   return v2
 }
 

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -15,11 +15,7 @@ chai.use(chaiAsPromised)
 chai.should()
 
 const defaults = {
-  'githubApp': {
-    'enabled': true,
-    'projectReportsEnabled': true,
-    'pullRequestAlertsEnabled': true,
-  },
+  'githubApp': {},
   'issueRules': {},
   'projectIgnorePaths': [],
 }


### PR DESCRIPTION
This way, users can opt into global/org defaults. Since we do this after parsing/validating, we need to differentiate between user set and unset config.

Here is the pattern: collections default to 0 value, concrete values should be nullable.