### PR TITLE
Expose a function to get the default config

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,9 +189,27 @@ async function parseV1SocketConfig (parsedV1Content) {
   return v2
 }
 
+/**
+ *
+ * @returns {SocketYml}
+ */
+function getDefaultConfig () {
+  const config = { version: 2 }
+  if (!validate(config)) {
+    throw new SocketValidationError(
+      'Invalid config definition',
+      validate.errors || [],
+      config
+    )
+  }
+
+  return config
+}
+
 module.exports = {
   parseSocketConfig,
   readSocketConfig,
   SocketValidationError,
   socketYmlSchema,
+  getDefaultConfig
 }

--- a/index.js
+++ b/index.js
@@ -189,27 +189,21 @@ async function parseV1SocketConfig (parsedV1Content) {
   return v2
 }
 
-/**
- *
- * @returns {SocketYml}
- */
+/** @returns {SocketYml} */
 function getDefaultConfig () {
   const config = { version: 2 }
+
   if (!validate(config)) {
-    throw new SocketValidationError(
-      'Invalid config definition',
-      validate.errors || [],
-      config
-    )
+    throw new Error('Unexpectedly invalid default config')
   }
 
   return config
 }
 
 module.exports = {
+  getDefaultConfig,
   parseSocketConfig,
   readSocketConfig,
   SocketValidationError,
   socketYmlSchema,
-  getDefaultConfig
 }

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -7,6 +7,7 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
 const {
+  getDefaultConfig,
   parseSocketConfig,
   SocketValidationError,
 } = require('../index.js')
@@ -14,7 +15,9 @@ const {
 chai.use(chaiAsPromised)
 chai.should()
 
+/** @type {import('../index.js').SocketYml} */
 const defaults = {
+  'version': 2,
   'githubApp': {},
   'issueRules': {},
   'projectIgnorePaths': [],
@@ -78,7 +81,7 @@ bar: {{ def }} {{ efg }}
 version: 2
 foo: true
 `)
-      .should.eventually.become({ version: 2, ...defaults })
+      .should.eventually.become(defaults)
   })
 
   it('should coerce types', async () => {
@@ -87,9 +90,14 @@ version: 2
 projectIgnorePaths: foobar
 `)
       .should.eventually.become({
-        version: 2,
         ...defaults,
         projectIgnorePaths: ['foobar'],
       })
+  })
+})
+
+describe('getDefaultConfig()', () => {
+  it('should return a default config', () => {
+    getDefaultConfig().should.deep.equal(defaults)
   })
 })


### PR DESCRIPTION
This is useful for filling in gaps where the user doesn't have a config. Open to any style changes. There might be a more efficient way to type narrow here. I'm not sure how to use never here. 