### PR TITLE
Add basic release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: npm bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      newversion:
+        description: "npm version {major,minor,patch}"
+        required: true
+
+env:
+  node_version: "19"
+  FORCE_COLOR: 1
+
+concurrency: # prevent concurrent releases
+  group: npm-bump
+  cancel-in-progress: true
+
+jobs:
+  version_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # fetch full history so things like auto-changelog work properly
+          fetch-depth: 0
+      - name: Use Node.js ${{ env.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+          # setting a registry enables the NODE_AUTH_TOKEN env variable where we can set an npm token.  REQUIRED
+          registry-url: "https://registry.npmjs.org"
+      - run: npm i
+      - run: npm test
+      - name: npm version && npm publish
+        uses: bcomnes/npm-bump@v2
+        with:
+          git_email: eng@socket.dev
+          git_username: ${{ github.actor }}
+          newversion: ${{ github.event.inputs.newversion }}
+          github_token: ${{ secrets.GITHUB_TOKEN }} # built in actions token.  Passed tp gh-release if in use.
+          npm_token: ${{ secrets.NPM_ORG_TOKEN }} # user set secret token generated at npm
+          publish_cmd: npm publish --provenance

--- a/package.json
+++ b/package.json
@@ -38,10 +38,13 @@
     "clean:declarations": "rm -rf $(find . -maxdepth 2 -type f -name '*.d.ts*')",
     "clean": "run-p clean:*",
     "prepare": "husky install",
-    "prepublishOnly": "run-s build",
+    "prepublishOnly": "git push --follow-tags && gh-release -y && run-s build",
     "test:mocha": "c8 --reporter=lcov --reporter text mocha 'test/**/*.spec.js'",
     "test-ci": "run-s test:*",
-    "test": "run-s check test:*"
+    "test": "run-s check test:*",
+    "version": "run-s prepare version:*",
+    "version:changelog": "auto-changelog -p --template keepachangelog auto-changelog --breaking-pattern 'BREAKING CHANGE:'",
+    "version:git": "git add CHANGELOG.md"
   },
   "devDependencies": {
     "@socketsecurity/eslint-config": "^2.0.0",
@@ -72,7 +75,9 @@
     "mocha": "^10.0.0",
     "npm-run-all2": "^6.0.2",
     "type-coverage": "^2.24.1",
-    "typescript": "~4.9.5"
+    "typescript": "~4.9.5",
+    "auto-changelog": "^2.4.0",
+    "gh-release": "^7.0.2"
   },
   "dependencies": {
     "ajv": "^8.12.0",


### PR DESCRIPTION
This release flow aims for the following features:
- npm version && npm publish works locally
- Action dispatch runs the same scripts as the local workflow
- Automatic build and changelog generation
- Github release support

@voxpelli if you want to factor something like this into the re-uesable workflow, let me know, or give me an idea how you want it done and I can do that. 